### PR TITLE
Fix Docker build context in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: |
             ${{ github.event_name == 'push' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
Added explicit `context: .` parameter to the Docker build step in the CI workflow to ensure the build uses the repository root as the build context.

## Changes
- Added `context: .` to the `docker/build-push-action@v6` step configuration in the CI workflow

## Details
This change explicitly specifies the build context for Docker builds in the CI pipeline. While the default behavior may work in many cases, explicitly setting the context ensures consistent and predictable builds across different environments and workflow configurations.

https://claude.ai/code/session_012iXz488f71pWNoP7ZfdY97

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just makes the Docker build context explicit; potential impact is limited to CI image build behavior.
> 
> **Overview**
> Ensures CI’s Docker image build uses the repository root as its build context by explicitly setting `context: .` on the `docker/build-push-action@v6` step, improving build determinism across events/environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 590083fd334e4fd25c49cbf710291449af4b7835. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->