### PR TITLE
Add GCP Cloud Run deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: read
 
     env:
       GCP_PROJECT_ID: gen-lang-client-0416698691
@@ -79,9 +80,6 @@ jobs:
       SERVICE_NAME: examiner
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2
@@ -95,19 +93,22 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push to Artifact Registry
-        uses: docker/build-push-action@v6
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          build-args: GITHUB_SHA
-          tags: |
-            ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.SERVICE_NAME }}:latest
-            ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull from GHCR, retag, and push to Artifact Registry
+        run: |
+          GHCR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-$(echo '${{ github.sha }}' | cut -c1-7)"
+          GAR_BASE="${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.SERVICE_NAME }}"
+          docker pull "$GHCR_IMAGE"
+          docker tag "$GHCR_IMAGE" "$GAR_BASE:latest"
+          docker tag "$GHCR_IMAGE" "$GAR_BASE:${{ github.sha }}"
+          docker push "$GAR_BASE:latest"
+          docker push "$GAR_BASE:${{ github.sha }}"
 
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2
@@ -115,12 +116,7 @@ jobs:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
           image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
-          flags: |
-            --min-instances=0
-            --max-instances=3
-            --port=3030
-            --allow-unauthenticated
-            --set-env-vars=RUST_LOG=info,PORT=3030,EXPIRY_DAYS=1
+          flags: '--min-instances=0 --max-instances=3 --port=3030 --allow-unauthenticated --set-env-vars=RUST_LOG=info,PORT=3030,EXPIRY_DAYS=1'
 
       - name: Show Cloud Run URL
         run: |


### PR DESCRIPTION
## Summary
This PR adds a new CI/CD workflow job to automatically deploy the application to Google Cloud Run on every push to the main branch.

## Key Changes
- Added `deploy-gcp` job to the CI workflow that:
  - Authenticates to Google Cloud using Workload Identity Federation
  - Builds and pushes Docker images to Google Artifact Registry with both `latest` and commit SHA tags
  - Deploys the image to Cloud Run with configured resource limits (0-3 instances) and environment variables
  - Outputs the deployed service URL for verification

## Implementation Details
- Deployment is triggered only on pushes to `main` branch and depends on successful Docker build completion
- Uses OIDC-based authentication (`google-github-actions/auth`) for secure, keyless GCP access
- Configures Cloud Run with:
  - Port 3030 for the application
  - Unauthenticated access enabled
  - Environment variables: `RUST_LOG=info`, `PORT=3030`, `EXPIRY_DAYS=1`
  - Auto-scaling between 0-3 instances
- Targets GCP project `gen-lang-client-0416698691` in `us-central1` region

https://claude.ai/code/session_01Uq8Mm72Wk89SXXBS8hAs1g

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated production deployment path with OIDC auth and unauthenticated Cloud Run exposure; misconfiguration could publish the service or deploy the wrong image.
> 
> **Overview**
> Adds a new `deploy-gcp` job to the CI workflow that runs *only on pushes to `main`* after the Docker job completes.
> 
> The job authenticates to GCP via Workload Identity Federation, builds and pushes an `amd64` image to Artifact Registry (tagged `latest` and `${{ github.sha }}`), then deploys that image to Cloud Run with autoscaling (0–3), port `3030`, unauthenticated access, and sets `RUST_LOG`, `PORT`, and `EXPIRY_DAYS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ad295198cee8ccad3a5d66d387766cc1235e6d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->