### PR TITLE
Switch final Docker image from scratch to Alpine with named user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ ENV VITE_SHA=${GITHUB_SHA}
 RUN npm run check
 RUN npm run build
 
-FROM scratch
+FROM alpine:latest
+RUN adduser -D -u 1000 appuser
+WORKDIR /app
 COPY --from=frontend /usr/src/app/dist dist
 COPY --from=backend /home/rust/src/target/release/examiner-server .
-USER 1000:1000
+USER appuser
 CMD [ "./examiner-server" ]


### PR DESCRIPTION
## Summary
Updated the final Docker image stage to use Alpine Linux instead of scratch, and replaced numeric user ID with a named user account for better security and maintainability.

## Key Changes
- Changed base image from `scratch` to `alpine:latest` for the final stage
- Added creation of a non-root user `appuser` with UID 1000
- Set working directory to `/app` for better organization
- Replaced `USER 1000:1000` with `USER appuser` for named user reference
- Maintained the same application functionality with improved container practices

## Implementation Details
- The Alpine base image provides essential utilities and a proper runtime environment, replacing the minimal scratch image
- User creation uses Alpine's `adduser` command with `-D` (no password) and `-u 1000` (specific UID) flags
- Named user reference improves readability and follows container security best practices
- Working directory explicitly set to `/app` for clearer application structure

https://claude.ai/code/session_01Gu5jHv3JjNA6vFS4x4Vx1u