### PR TITLE
fix: force cargo recompilation to prevent dummy binary deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
           image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
-          flags: '--min-instances=0 --max-instances=3 --port=3030 --allow-unauthenticated --set-env-vars=RUST_LOG=info,EXPIRY_DAYS=1'
+          flags: '--min-instances=0 --max-instances=3 --port=3030 --allow-unauthenticated'
+          env_vars: |
+            RUST_LOG=info
+            EXPIRY_DAYS=1
 
       - name: Show Cloud Run URL
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:alpine AS backend
+FROM --platform=amd64 rust:alpine AS backend
 WORKDIR /home/rust/src
-RUN apk --no-cache add musl-dev openssl-dev
+RUN apk --no-cache add musl-dev
 
 # Cache dependencies — only invalidated when Cargo.toml/Cargo.lock change
 COPY Cargo.toml Cargo.lock ./
@@ -13,9 +13,10 @@ RUN mkdir -p examiner-server/src examiner-wasm/src \
     && cargo build --release --package examiner-server \
     && rm -rf examiner-server/src examiner-wasm/src
 
-# Build actual source (cached deps are reused)
+# Build actual source — touch ensures mtimes are newer than cached artifacts
 COPY . .
-RUN cargo build --release --package examiner-server
+RUN touch examiner-server/src/main.rs examiner-server/src/lib.rs && \
+    cargo build --release --package examiner-server
 
 FROM --platform=amd64 rust:alpine AS wasm
 WORKDIR /home/rust/src
@@ -40,5 +41,7 @@ RUN adduser -D -u 1000 appuser
 WORKDIR /app
 COPY --from=frontend /usr/src/app/dist dist
 COPY --from=backend /home/rust/src/target/release/examiner-server .
+RUN ldd examiner-server 2>&1 || true && \
+    wc -c < examiner-server
 USER appuser
 CMD [ "./examiner-server" ]

--- a/examiner-server/src/main.rs
+++ b/examiner-server/src/main.rs
@@ -10,6 +10,8 @@ async fn main() {
         .parse()
         .expect("Unable to parse PORT");
 
+    eprintln!("examiner: configuring server");
+
     let config = ServerConfig {
         expiry_days: std::env::var("EXPIRY_DAYS")
             .unwrap_or_else(|_| String::from("1"))
@@ -25,5 +27,6 @@ async fn main() {
         },
     };
 
+    eprintln!("examiner: starting on 0.0.0.0:{}", port);
     warp::serve(server(config)).run(([0, 0, 0, 0], port)).await;
 }


### PR DESCRIPTION
The Docker dependency caching trick creates a dummy `fn main() {}` binary to cache dependencies, then rebuilds with real source. However, Docker COPY preserves original file timestamps which can be older than the cached build artifacts, causing cargo to skip recompilation and ship the do-nothing dummy binary.

Fix by touching source files before cargo build to ensure their mtimes are newer than cached artifacts. Also:
- Add --platform=amd64 to backend stage (consistency with other stages)
- Remove unnecessary openssl-dev (no openssl-sys in dependency tree)
- Add ldd/wc verification step to catch wrong binary at build time
- Add startup eprintln diagnostics to aid Cloud Run log debugging
- Move env_vars to deploy-cloudrun action's native parameter

https://claude.ai/code/session_01Gu5jHv3JjNA6vFS4x4Vx1u