### PR TITLE
Improve proctoring event tracking and fix focus loss double-counting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,12 +64,23 @@ function initExaminerUrl(sessionId: string) {
 export type ProctoringStats = Record<number, Record<string, number>>;
 
 /** Enables proctored mode on a Monaco editor instance, blocking clipboard and drag-drop. */
-function enableProctoredMode(ed: editor.IStandaloneCodeEditor) {
+function enableProctoredMode(
+  ed: editor.IStandaloneCodeEditor,
+  onClipboardAttempt?: (eventType: string) => void,
+) {
   // Layer 1: Override Monaco clipboard keybindings
-  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyC, () => {});
-  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyX, () => {});
-  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyV, () => {});
-  ed.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV, () => {});
+  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyC, () => {
+    onClipboardAttempt?.("copy_attempt");
+  });
+  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyX, () => {
+    onClipboardAttempt?.("cut_attempt");
+  });
+  ed.addCommand(KeyMod.CtrlCmd | KeyCode.KeyV, () => {
+    onClipboardAttempt?.("paste_attempt");
+  });
+  ed.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyV, () => {
+    onClipboardAttempt?.("paste_attempt");
+  });
 
   // Layer 2: DOM-level clipboard event blocking
   const domNode = ed.getDomNode();
@@ -193,9 +204,11 @@ function App() {
       }
     };
     const handleBlur = () => {
-      examiner.current?.sendFocusChange(true);
-      setFocusLossCount((c) => c + 1);
-      examiner.current?.sendProctoringEvent("tab_switch");
+      // Only update focus state; counting is handled by visibilitychange
+      // to avoid double-incrementing (both events fire on tab switch).
+      if (!document.hidden) {
+        examiner.current?.sendFocusChange(true);
+      }
     };
     const handleFocus = () => {
       examiner.current?.sendFocusChange(false);
@@ -457,7 +470,9 @@ function App() {
                 dragAndDrop: false,
               }}
               onMount={(ed) => {
-                enableProctoredMode(ed);
+                enableProctoredMode(ed, (eventType) => {
+                  examiner.current?.sendProctoringEvent(eventType);
+                });
                 setEditorInstance(ed);
               }}
             />

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -309,6 +309,16 @@ function Sidebar({
           ? "Upload a questions file to begin. Share the link with candidates. Download the code when the interview is complete."
           : "Copy and paste are disabled. Your activity is being monitored."}
       </Text>
+      <Text fontSize="xs" mt={2}>
+        <a
+          href="https://github.com/harshalsoni/examiner"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "underline" }}
+        >
+          GitHub
+        </a>
+      </Text>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
This PR enhances the proctoring system to better track clipboard attempts and fixes a bug where focus loss events were being double-counted. It also adds a GitHub link to the sidebar.

## Key Changes

- **Enhanced clipboard attempt tracking**: Modified `enableProctoredMode()` to accept an optional callback that reports specific clipboard operation types (copy, cut, paste) instead of silently blocking them. This allows the examiner to track which clipboard operations were attempted.

- **Fixed focus loss double-counting**: Removed the automatic `setFocusLossCount` increment from the blur handler and the redundant `sendProctoringEvent("tab_switch")` call. The focus loss count is now only incremented via the `visibilitychange` event to prevent double-counting when users switch tabs (both blur and visibilitychange events fire).

- **Improved focus state handling**: The blur handler now only sends focus change updates when the document is not hidden, preventing unnecessary state updates during tab switches.

- **Added GitHub link**: Added a GitHub repository link in the sidebar footer for easy access to the project source code.

## Implementation Details

- The `onClipboardAttempt` callback in `enableProctoredMode()` is called with event type strings: `"copy_attempt"`, `"cut_attempt"`, and `"paste_attempt"` (for both Ctrl+V and Ctrl+Shift+V).
- The focus loss tracking now relies on the `visibilitychange` event as the single source of truth for tab switches, making the event tracking more reliable and preventing duplicate counts.

https://claude.ai/code/session_01FPD9UFUzFBYtMG5j4HfCet